### PR TITLE
Add gitignore, editorconfig, fix shell script permissions and shabang

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = tab
+tab_width = 4
+
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build/
+/bin/
+/eclipse/
+.DS_Store
+/Visual Studio 15 2017/

--- a/linux_build.sh
+++ b/linux_build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 # For Unix (OSX and Linux)
 

--- a/linux_project_eclipse.sh
+++ b/linux_project_eclipse.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 # For Unix (OSX and Linux) Eclipse
 


### PR DESCRIPTION
This pull request adds:

* `.gitignore` in order to avoid indexing build/output directories in git
* `.editorconfig` to allow different editors/IDE to load the same settings for indentation and newline
* shabang inside both Linux scripts in order to use `/bin/sh` to execute them

This PR adds also the executable bit on both Linux scripts